### PR TITLE
Fix Cloudwatch Service

### DIFF
--- a/aws/cloudwatch/service.go
+++ b/aws/cloudwatch/service.go
@@ -2,18 +2,18 @@
 package cloudwatch
 
 import (
-	"github.com/GSA/grace-tftest/aws/cloudwatchevents/rule"
+	"github.com/GSA/grace-tftest/aws/cloudwatch/metric"
 	"github.com/aws/aws-sdk-go/aws/client"
 )
 
 // Service contains all the supported types for IAM
 type Service struct {
-	Metric *rule.Rule
+	Metric *metric.Metric
 }
 
 // New returns a new *Service
 func New(client client.ConfigProvider) *Service {
 	return &Service{
-		Metric: rule.New(client),
+		Metric: metric.New(client),
 	}
 }


### PR DESCRIPTION
- `service.go` was referencing `cloudwatchevents/rule` instead of `cloudwatch/metric`