### PR TITLE
Fix slice length and attribute types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 */.DS_Store
 vendor/
+coverage.out
 
 ## Jetbrains ##
 .idea

--- a/aws/kms/key/key.go
+++ b/aws/kms/key/key.go
@@ -286,7 +286,7 @@ func (a *Key) keys() ([]*kms.KeyMetadata, error) {
 	if err != nil {
 		return nil, err
 	}
-	keys := make([]*kms.KeyMetadata, 0, len(entries))
+	keys := make([]*kms.KeyMetadata, len(entries))
 	for i, k := range entries {
 		input := kms.DescribeKeyInput{KeyId: k.KeyId}
 		resp, err := svc.DescribeKey(&input)

--- a/aws/kms/service.go
+++ b/aws/kms/service.go
@@ -2,17 +2,20 @@ package kms
 
 import (
 	"github.com/GSA/grace-tftest/aws/kms/alias"
+	"github.com/GSA/grace-tftest/aws/kms/key"
 	"github.com/aws/aws-sdk-go/aws/client"
 )
 
 // Service contains all the supported types for S3
 type Service struct {
 	Alias *alias.Alias
+	Key   *key.Key
 }
 
 // New returns a new *Service
 func New(client client.ConfigProvider) *Service {
 	return &Service{
 		Alias: alias.New(client),
+		Key:   key.New(client),
 	}
 }

--- a/aws/sns/topic/topic.go
+++ b/aws/sns/topic/topic.go
@@ -25,12 +25,12 @@ type Attributes struct {
 	Policy                  string
 	DeliveryPolicy          string
 	Owner                   string
-	SubscriptionsPending    int64
+	SubscriptionsPending    string
 	TopicArn                string
 	EffectiveDeliveryPolicy string
-	SubscriptionsConfirmed  int64
+	SubscriptionsConfirmed  string
 	DisplayName             string
-	SubscriptionsDeleted    int64
+	SubscriptionsDeleted    string
 	KmsMasterKeyID          string `json:"KmsMasterKeyId"`
 }
 
@@ -210,7 +210,7 @@ func (r *Topic) topics() ([]*Attributes, error) {
 		return nil, err
 	}
 
-	attributes := make([]*Attributes, 0, len(topics))
+	attributes := make([]*Attributes, len(topics))
 	for i, t := range topics {
 		resp, err := svc.GetTopicAttributes(&sns.GetTopicAttributesInput{TopicArn: t.TopicArn})
 		if err != nil {
@@ -233,7 +233,7 @@ func unmarshal(m map[string]*string) (*Attributes, error) {
 	}
 
 	var a *Attributes
-	err = json.Unmarshal(b, a)
+	err = json.Unmarshal(b, &a)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/sns/topic/topic_test.go
+++ b/aws/sns/topic/topic_test.go
@@ -7,10 +7,13 @@ import (
 func TestTopic(t *testing.T) {
 	topics := []*Attributes{
 		{
-			TopicArn: "a",
+			TopicArn:       "a",
+			DisplayName:    "b",
+			Owner:          "c",
+			KmsMasterKeyID: "d",
 		},
 	}
-	topic := New(nil).TopicArn("a").Assert(t, topics...)
+	topic := New(nil).TopicArn("a").Arn("a").DisplayName("b").Name("b").Owner("c").KmsMasterKeyID("d").Assert(t, topics...)
 	if topic == nil {
 		t.Error("topic should not be nil")
 	}


### PR DESCRIPTION
I did some live testing and discovered some issues:

- Since I'm not using append, need to initialize the slice length to be the same as the capacity
- The integers in the SNS Topic attributes are really strings
- Adds Key to kms/service type